### PR TITLE
Adding custom ddr prop support

### DIFF
--- a/ClientFaux/ClientFaux.csproj
+++ b/ClientFaux/ClientFaux.csproj
@@ -178,6 +178,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>rem robocopy C:\git\ClientFaux\ClientFaux\bin\Debug \\DC2016\Debug &amp; exit 0</PostBuildEvent>
+    <PostBuildEvent>robocopy C:\git\ClientFaux\ClientFaux\bin\Debug \\DC2016\Debug &amp; exit 0</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/ClientFaux/ClientFaux.csproj
+++ b/ClientFaux/ClientFaux.csproj
@@ -24,7 +24,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>4</ApplicationRevision>
+    <ApplicationRevision>5</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -178,7 +178,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <PostBuildEvent>rem robocopy C:\git\ClientFaux\ClientFaux\bin\Debug \\DC2016\Debug &amp; exit 0</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/ClientFaux/ClientFaux.csproj
+++ b/ClientFaux/ClientFaux.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -178,6 +179,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>robocopy C:\git\ClientFaux\ClientFaux\bin\Debug \\DC2016\Debug &amp; exit 0</PostBuildEvent>
+    <PostBuildEvent>rem robocopy C:\git\ClientFaux\ClientFaux\bin\Debug \\DC2016\Debug &amp; exit 0</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/ClientFaux/FauxDeployCMAgent.cs
+++ b/ClientFaux/FauxDeployCMAgent.cs
@@ -10,6 +10,7 @@ using static CMFaux.CMFauxStatusViewClasses;
 using Microsoft.ConfigurationManagement.Messaging.Messages.Server;
 using System.IO;
 using CERTENROLLLib;
+using System.Collections.ObjectModel;
 
 namespace CMFaux
 {
@@ -181,14 +182,14 @@ namespace CMFaux
                 hinvMessage.SendMessage(Sender);
             };
         }
-        public static void SendCustomDiscovery(string CMServerName, string ClientName, string SiteCode, string FilePath, List<CustomClientRecord> customClientRecords)
+        public static void SendCustomDiscovery(string CMServerName, string ClientName, string SiteCode, string FilePath, ObservableCollection<CustomClientRecord> customClientRecords)
         {
             string ddmLocal = FilePath + "\\DDRS\\" + ClientName;
             string CMddmInbox = "\\\\" + CMServerName + "\\SMS_" + SiteCode + "\\inboxes\\ddm.box\\" + ClientName + ".DDR";
             
             DiscoveryDataRecordFile ddrF = new DiscoveryDataRecordFile("ClientFaux");
             ddrF.SiteCode = SiteCode;
-            ddrF.Architecture = "System";            
+            ddrF.Architecture = "System";
             ddrF.AddStringProperty("Name", DdmDiscoveryFlags.Key, 32, ClientName);
             ddrF.AddStringProperty("Netbios Name", DdmDiscoveryFlags.Name, 16, ClientName);
 

--- a/ClientFaux/MainWindow.xaml
+++ b/ClientFaux/MainWindow.xaml
@@ -14,10 +14,11 @@
                     <Button MinHeight="40" Background="#FF001741" Foreground="#FFF2EAEA" Content="✈ Ready..."  Name="ReadyButton" BorderBrush="#FF001741" HorizontalAlignment="Left" HorizontalContentAlignment="Left" Click="ReadyButton_Click" Width="119" />
                     <Button MinHeight="40" Background="#FF001741" Foreground="#FFF2EAEA" Content="📜 Certificates"  Name="Certificates" BorderBrush="#FF001741" HorizontalAlignment="Left" HorizontalContentAlignment="Left" Click="Certificates_Click" Width="119"/>
                     <Button MinHeight="40" Background="#FF001741" Foreground="#FFF2EAEA" Content="📝 Device Naming" Name="DeviceNaming" BorderBrush="#FF001741" HorizontalAlignment="Left" HorizontalContentAlignment="Left" Click="DeviceNaming_Click"/>
+                    <Button MinHeight="40" Background="#FF001741" Foreground="#FFF2EAEA" Content="📄 Inventory" Name="Inventory" BorderBrush="#FF001741" HorizontalAlignment="Left" HorizontalContentAlignment="Left" Click="Inventory_Click" Width="119"/>
                     <Button MinHeight="40" Background="#FF001741" Foreground="#FFF2EAEA" Content="🌐 Configure CM"  Name="SCCMSettings" BorderBrush="#FF001741" HorizontalAlignment="Left" HorizontalContentAlignment="Left" Click="SCCMSettings_Click" />
                 </StackPanel>
             </Expander>
-            <TabControl Name="TabControl" BorderBrush="White" >
+            <TabControl Name="TabControl" BorderBrush="White">
                 <TabControl.ItemContainerStyle>
                     <Style TargetType="{x:Type TabItem}">
                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -114,6 +115,53 @@
                             <TextBox ToolTip="How many threads woudl you like to use?  Seven will max out even very beefy systems." Name="MaximumThreads" PreviewTextInput="TextBox_OnEndingButtonTextInput" Width="20px" HorizontalAlignment="Left" Margin="0,0,30,0" TextChanged="MaximumThreads_TextChanged"></TextBox>
                             <Label>Number of Fake CM Clients to be created </Label>
                             <TextBlock Name="NumberOfClients" Foreground="#FF1053CD">Count will appear here</TextBlock>
+                        </StackPanel>
+                    </Grid>
+                </TabItem>
+                <TabItem Name="InventoryPanel">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="400*" />
+                            <ColumnDefinition Width="400*" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Margin="10" HorizontalAlignment="Left">
+                            <Label FontFamily="Calibri" FontSize="22px">Custom Inventory Settings</Label>
+                            <TextBlock TextWrapping="WrapWithOverflow">ClientFaux can report many types of custom inventory.</TextBlock>
+                            <Label FontSize="20">Discovery Custom Properties</Label>
+                            <Label>PropertyName</Label>
+                            <TextBox ToolTip="The three letter acronym of your CM Primary Site, something like [F0X]." Name="NewDDRProp" HorizontalAlignment="Left" MaxWidth="180px" Margin="0,0,20,0" MinWidth="120px">MyCustomProp</TextBox>
+                            <Label>PropertyValue</Label>
+                            <TextBox ToolTip="The starting digit when making multiple clients, something like [10]." Name="NewDDRValue" HorizontalAlignment="Left" Margin="0,0,10,0" MinWidth="120px">MyCustomValue</TextBox>
+                            <Button Content="Save" Margin="0,10,10,10" Width="80px" HorizontalAlignment="Left" Click="SaveButton_Click"></Button>
+                            <DataGrid Name="dgInventory" AutoGenerateColumns="False" MaxHeight="500" MaxWidth="400" HorizontalAlignment="Left">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Property" Binding="{Binding RecordName}" IsReadOnly="True"/>
+                                    <DataGridTextColumn Header="Value" Binding="{Binding RecordValue}" IsReadOnly="True" />
+                                </DataGrid.Columns>
+                                <!--<DataGrid.RowDetailsTemplate>
+                                    <DataTemplate>
+                                        <DockPanel Background="GhostWhite">
+                                            <Image DockPanel.Dock="Left" Source="{Binding ImageSource}" Height="64" Margin="10" />
+                                            <Grid Margin="0,10">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <TextBlock Text="Name: " FontWeight="Bold" Grid.Row="1" />
+                                                <TextBlock Text="{Binding Name}" Grid.Column="1" Grid.Row="1" />
+                                                <TextBlock Text="Client Status: " FontWeight="Bold" Grid.Row="2" />
+                                                <TextBlock Text="{Binding Status}" Grid.Column="1" Grid.Row="2" />
+                                                <ProgressBar Grid.Column="1" Minimum="0" Maximum="100" Value="{Binding ProcessProgress}" MaxWidth="150px" Height="18" FlowDirection="LeftToRight"/>
+                                            </Grid>
+                                        </DockPanel>
+                                    </DataTemplate>
+                                </DataGrid.RowDetailsTemplate>-->
+                            </DataGrid>
                         </StackPanel>
                     </Grid>
                 </TabItem>

--- a/ClientFaux/MainWindow.xaml
+++ b/ClientFaux/MainWindow.xaml
@@ -42,7 +42,7 @@
                             <Label Name="ClientCount" FontSize="24">Device Count</Label>
                             <Label Name="Counter" FontSize="24" Content="{Binding IdCounter}"/>
                             <Expander Name="DeviceExpander" >
-                                <ContentControl HorizontalAlignment="Left" Margin="10,0,0,0" MaxWidth="700"> 
+                                <ContentControl HorizontalAlignment="Left" Margin="10,0,0,0" MaxWidth="700">
                                     <DataGrid Name="dgDevices" AutoGenerateColumns="False" MaxHeight="500">
                                         <DataGrid.Columns>
                                             <DataGridTextColumn Header="Name" Binding="{Binding Name}" IsReadOnly="True"/>
@@ -55,6 +55,11 @@
                                                 </DataGridTemplateColumn.CellTemplate>
                                             </DataGridTemplateColumn>
                                         </DataGrid.Columns>
+                                        <DataGrid.ItemContainerStyle>
+                                            <Style TargetType="DataGridRow">
+                                                <EventSetter Event="PreviewMouseLeftButtonDown" Handler="OnMouseDown"/>
+                                            </Style>
+                                        </DataGrid.ItemContainerStyle>
                                         <DataGrid.RowDetailsTemplate>
                                             <DataTemplate>
                                                 <DockPanel Background="GhostWhite">

--- a/ClientFaux/MainWindow.xaml.cs
+++ b/ClientFaux/MainWindow.xaml.cs
@@ -330,5 +330,14 @@ namespace CMFaux
             NewDDRValue.Text = null;
             NewDDRProp.Text = null;
         }
+
+        private void OnMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            DataGridRow row = sender as DataGridRow;
+            if (row != null)
+            {
+                row.DetailsVisibility = row.IsSelected ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+            }
+        }
     }
 }

--- a/ClientFaux/Properties/AssemblyInfo.cs
+++ b/ClientFaux/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]


### PR DESCRIPTION
Exposes support to add your own DDR Properties, and also fixes a few weird bugs.

![image](https://user-images.githubusercontent.com/1247626/57944882-5d7eb500-78a6-11e9-80f4-e895b13aaed9.png)

Each device created will report the properties listed here, including the tattoo property of `ClientKind` which you can use to filter these devices out in your CM infrastructure.